### PR TITLE
feat:fixtures目录能支持2级， req&resp支持添加额外标题信息

### DIFF
--- a/tep/client.py
+++ b/tep/client.py
@@ -23,6 +23,10 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 def request_encapsulate(req):
     def send(*args, **kwargs):
         start = time.process_time()
+        case_title = ""
+        if "case_title" in kwargs:
+            case_title = kwargs.get("case_title") + " "
+            kwargs.pop("case_title")
         response = req(*args, **kwargs)
         end = time.process_time()
         elapsed = str(decimal.Decimal("%.3f" % float(end - start))) + "s"
@@ -38,7 +42,7 @@ def request_encapsulate(req):
                 kv += f" {k}:{v} "
             request_response = log4a.format(args[0], kv, response.status_code, response.text, elapsed)
             logger.info(request_response)
-            allure.attach(request_response, 'request & response', allure.attachment_type.TEXT)
+            allure.attach(request_response, f'{case_title}request & response', allure.attachment_type.TEXT)
         except AttributeError:
             logger.error("request failed")
         except TypeError:

--- a/tep/scaffold.py
+++ b/tep/scaffold.py
@@ -99,6 +99,7 @@ def _project_cache(request):
 
 
 # Auto import fixtures
+_fixtures_dir = os.path.join(_project_dir, "fixtures")
 for root, _, files in os.walk(_fixtures_dir):
     for file in files:
         if os.path.isfile(os.path.join(root, file)):

--- a/tep/scaffold.py
+++ b/tep/scaffold.py
@@ -99,18 +99,22 @@ def _project_cache(request):
 
 
 # Auto import fixtures
-_fixtures_dir = os.path.join(_project_dir, "fixtures")
 for root, _, files in os.walk(_fixtures_dir):
     for file in files:
         if os.path.isfile(os.path.join(root, file)):
             if file.startswith("fixture_") and file.endswith(".py"):
+                parent_path = ""
                 _fixture_name, _ = os.path.splitext(file)
+                fixture_path = _fixture_name
+                if root != _fixtures_dir:
+                    parent_path = os.path.split(root)[-1]
+                    fixture_path = ".".join([parent_path, _fixture_name])
                 try:
-                    exec(f"from fixtures.{_fixture_name} import *")
+                    exec(f"from fixtures.{fixture_path} import *")
                 except:
                     pass
                 try:
-                    exec(f"from .fixtures.{_fixture_name} import *")
+                    exec(f"from .fixtures.{fixture_path} import *")
                 except:
                     pass
 """


### PR DESCRIPTION
### fixtures
1.  效果如下，
![image](https://user-images.githubusercontent.com/38233062/150498353-a4884b63-7005-451c-8f7b-d78818b77786.png)
1. 坑  其他地方conftest.py 模块出错的时候，控制台日志会识别到根路径下conftest.py 出错

### req&resp支持自定义title 
1.  每条req&resp 实际就是一条case ; 有时候要解决前后依赖的问题，不想写多个测试函数，在一个测试函数中多次req&resp ,这个时候通过添加标题来达到区分case的目的
![image](https://user-images.githubusercontent.com/38233062/150499045-5612a53f-400b-43d8-aded-6186fe7e5b27.png)
1. 使用 
![image](https://user-images.githubusercontent.com/38233062/150500796-7fc9a3c8-a13f-4f13-b5c5-77660c1baed1.png)



